### PR TITLE
Fix readme cron entries

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,2 @@
 @reboot cd /home/ubuntu/app-root && pm2 start ecosystem.config.js --env development
-
 0 4 * * * pm2 restart ecosystem.config.js --env development


### PR DESCRIPTION
## Summary
- clean up the cron instructions in `readme.txt`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686043470a148321baea6b1cecceacbc