### PR TITLE
Fix API timestamp generation

### DIFF
--- a/example-app/example-api-app.js
+++ b/example-app/example-api-app.js
@@ -2,10 +2,8 @@ const express = require('express');
 const app = express();
 const PORT = 4000;
 
-// Example data payload for AppOne
+// Static payload used for the example API
 const exampleData = {
-  status: 'ok',
-  timestamp: Date.now(),
   payload: {
     key1: {
       sub_key1: [
@@ -27,8 +25,13 @@ const exampleData = {
 };
 
 // Define the endpoint
+// Include a fresh timestamp for each request
 app.get('/api/app1', (req, res) => {
-  res.json(exampleData);
+  res.json({
+    status: 'ok',
+    timestamp: Date.now(),
+    ...exampleData
+  });
 });
 
 // Start server


### PR DESCRIPTION
## Summary
- ensure example API returns a fresh timestamp for every request

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860417b5b248321b0bac25f422ab0e6