### PR TITLE
Add chart display support with multiple chart types

### DIFF
--- a/client/src/components/AppPage.js
+++ b/client/src/components/AppPage.js
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import DataTable from './DataTable';
+import Chart from './Chart';
 
 function AppPage() {
   const { name } = useParams();
@@ -21,7 +22,7 @@ function AppPage() {
       try {
         const resp = await fetch(`/api/data/${name}`);
         const json = await resp.json();
-        const apiResult = json.payload;                   // { status, timestamp, payload: {...} }
+        const apiResult = json.payload; // { status, timestamp, payload: {...} }
         const actualSections = apiResult && apiResult.payload ? apiResult.payload : {};
         if (mounted) setSections(actualSections);
       } catch {
@@ -64,15 +65,26 @@ function AppPage() {
         ))}
       </div>
 
-      {/* Render only the active tab's tables, guard mapping */}
+      {/* Render only the active tab's tables or charts */}
       {activeTab && (
         <div className="section">
-          {Object.entries(activeSection).map(([subKey, arr]) => (
-            <div key={subKey} className="section mb-6">
-              <h3 className="text-lg mb-2">{subKey}</h3>
-              <DataTable data={Array.isArray(arr) ? arr : []} />
-            </div>
-          ))}
+          {Object.entries(activeSection).map(([subKey, value]) => {
+            const isConfig = value && typeof value === 'object' && !Array.isArray(value);
+            const display = isConfig && value.display ? value.display : 'table';
+            const data = isConfig && value.data ? value.data : value;
+            const chartType = isConfig && value.chartType ? value.chartType : 'line';
+
+            return (
+              <div key={subKey} className="section mb-6">
+                <h3 className="text-lg mb-2">{subKey}</h3>
+                {display === 'chart' ? (
+                  <Chart data={Array.isArray(data) ? data : []} type={chartType} />
+                ) : (
+                  <DataTable data={Array.isArray(data) ? data : []} />
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/client/src/components/Chart.js
+++ b/client/src/components/Chart.js
@@ -4,7 +4,7 @@
 import React, { useEffect, useRef } from 'react';
 import ChartJS from 'chart.js/auto';
 
-function Chart({ data }) {
+function Chart({ data, type = 'line' }) {
   const canvasRef = useRef(null);
   const chartInstanceRef = useRef(null);
 
@@ -22,7 +22,7 @@ function Chart({ data }) {
 
     // Create new chart
     chartInstanceRef.current = new ChartJS(ctx, {
-      type: 'line',
+      type,
       data: {
         labels: data.map((_, i) => i),
         datasets: Object.keys(data[0]).map(key => ({
@@ -44,7 +44,7 @@ function Chart({ data }) {
         chartInstanceRef.current = null;
       }
     };
-  }, [data]);
+  }, [data, type]);
 
   return (
     <canvas

--- a/example-app/example-api-app.js
+++ b/example-app/example-api-app.js
@@ -14,14 +14,22 @@ function stockSnapshot() {
   return {
 
     key1: {
-      sub_key1: [
-        { symbol: 'AAA', price: rand(100, 150) },
-        { symbol: 'BBB', price: rand(200, 250) }
-      ],
-      sub_key2: [
-        { metric: 'volume', value: rand(1000, 5000) },
-        { metric: 'pe_ratio', value: rand(10, 20) }
-      ]
+      sub_key1: {
+        display: 'chart',
+        chartType: 'line',
+        data: [
+          { symbol: 'AAA', price: rand(100, 150) },
+          { symbol: 'BBB', price: rand(200, 250) }
+        ]
+      },
+      sub_key2: {
+        display: 'chart',
+        chartType: 'bar',
+        data: [
+          { metric: 'volume', value: rand(1000, 5000) },
+          { metric: 'pe_ratio', value: rand(10, 20) }
+        ]
+      }
     },
     key2: {
       sub_key3: [
@@ -37,14 +45,22 @@ function forexSnapshot() {
   return {
 
     key1: {
-      sub_key1: [
-        { pair: 'EUR/USD', rate: rand(1.05, 1.15) },
-        { pair: 'USD/JPY', rate: rand(109, 111) }
-      ],
-      sub_key2: [
-        { pair: 'GBP/USD', rate: rand(1.2, 1.3) },
-        { pair: 'USD/CAD', rate: rand(1.25, 1.35) }
-      ]
+      sub_key1: {
+        display: 'chart',
+        chartType: 'line',
+        data: [
+          { pair: 'EUR/USD', rate: rand(1.05, 1.15) },
+          { pair: 'USD/JPY', rate: rand(109, 111) }
+        ]
+      },
+      sub_key2: {
+        display: 'chart',
+        chartType: 'bar',
+        data: [
+          { pair: 'GBP/USD', rate: rand(1.2, 1.3) },
+          { pair: 'USD/CAD', rate: rand(1.25, 1.35) }
+        ]
+      }
     },
     key2: {
       sub_key3: [


### PR DESCRIPTION
## Summary
- support rendering charts in the client when API sends `display: 'chart'`
- allow line or bar chart selection via `chartType` prop
- update example API to send new structure with display hints

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860b004cc5c83218ae101401494d08b