### PR TITLE
Add deploy script for editor assets

### DIFF
--- a/bin/deploy-editor.sh
+++ b/bin/deploy-editor.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# bin/deploy-editor.sh: Deploy editor assets
+
+set -e
+
+SRC="/home3/kzenginf/git/editor"
+DEST="/home3/kzenginf/public_html/book/editor"
+
+mkdir -p "$DEST"
+
+rsync -av --include='*/' --include='*.php' --include='*.js' --include='*.css' --exclude='*' "$SRC/" "$DEST/"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "jest"
+    "test": "jest",
+    "deploy-editor": "bash bin/deploy-editor.sh"
   },
   "dependencies": {
     "chokidar": "^3.5.3",

--- a/readme.txt
+++ b/readme.txt
@@ -1,2 +1,7 @@
 @reboot cd /home/ubuntu/app-root && pm2 start ecosystem.config.js --env development
 0 4 * * * pm2 restart ecosystem.config.js --env development
+
+# Deploy editor assets
+Run `npm run deploy-editor` to copy PHP, JavaScript and CSS files
+from `/home3/kzenginf/git/editor` to
+`/home3/kzenginf/public_html/book/editor`.


### PR DESCRIPTION
## Summary
- add `bin/deploy-editor.sh` to sync PHP, JS and CSS files
- expose deployment via npm script `deploy-editor`
- document deployment command in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68804b4f61f883219cea8a50b95df16f